### PR TITLE
fix: deprecated use of ++en-json and ++de-json

### DIFF
--- a/app/language-server.hoon
+++ b/app/language-server.hoon
@@ -585,5 +585,5 @@
       =/  =mark  (rear path)
       =/  =type  [%atom %t ~]
       =-  (cite desk path -)
-      [mark [type ?:(=(%hoon mark) txt (need (de-json:html txt)))]]
+      [mark [type ?:(=(%hoon mark) txt (need (de:json:html txt)))]]
 --

--- a/lib/server.hoon
+++ b/lib/server.hoon
@@ -19,7 +19,7 @@
 ++  json-to-octs
   |=  jon=json
   ^-  octs
-  (as-octt:mimes:html (en-json:html jon))
+  (as-octs:mimes:html (en:json:html jon))
 ::
 ++  app
   |%

--- a/mar/json.hoon
+++ b/mar/json.hoon
@@ -13,11 +13,11 @@
 ++  grow                                                ::  convert to
   |%
   ++  mime  [/application/json (as-octs:mimes -:txt)]   ::  convert to %mime
-  ++  txt   [(crip (en-json jon))]~
+  ++  txt   [(crip (en:json jon))]~
   --
 ++  grab
   |%                                                    ::  convert from
-  ++  mime  |=([p=mite q=octs] (fall (rush (@t q.q) apex:de-json) *json))
+  ++  mime  |=([p=mite q=octs] (fall (rush (@t q.q) apex:de:json) *json))
   ++  noun  json                                        ::  clam from %noun
   ++  numb  numb:enjs
   ++  time  time:enjs


### PR DESCRIPTION
use ++en:json and ++de:json instead.

https://docs.urbit.org/language/hoon/reference/zuse/2e_2-3#en-jsonhtml